### PR TITLE
Patch conda load

### DIFF
--- a/pyMKL/loadMKL.py
+++ b/pyMKL/loadMKL.py
@@ -9,22 +9,21 @@ libname = {'linux':'libmkl_rt.so', # works for python3 on linux
            'win32':'mkl_rt.dll'}
 
 def _loadMKL():
-    
+
     try:
         # Look for MKL in path
         MKLlib = CDLL(libname[platform])
     except:
         try:
             # Look for anaconda mkl
-            if 'Anaconda' in sys.version:
-                if platform in ['linux', 'linux2','darwin']:
-                    libpath = ['/']+sys.executable.split('/')[:-2] + \
-                              ['lib',libname[platform]]
-                elif platform == 'win32':
-                    libpath = sys.executable.split(os.sep)[:-1] + \
-                              ['Library','bin',libname[platform]]
-                MKLlib = CDLL(os.path.join(*libpath))
-        except Exception as e: 
+            cdll_path = os.environ['CONDA_PREFIX']
+            if platform in ['linux', 'linux2','darwin']:
+                libpath = ['lib']
+            elif platform == 'win32':
+                libpath = ['Library','bin']
+            cdll_path = os.path.join(cdll_path, *libpath, _libname[platform])
+            MKLlib = CDLL(cdll_path)
+        except Exception as e:
             raise e
 
     return MKLlib


### PR DESCRIPTION
When installing a python version from Conda-forge the `Anaconda` is not present in the sys.version string, thus it will never be seen as an anaconda install. Best practice is just to try to load it from the anaconda path it would be in.