### PR TITLE
Fixes import issue on latest MKL version

### DIFF
--- a/pyMKL/loadMKL.py
+++ b/pyMKL/loadMKL.py
@@ -9,14 +9,20 @@ libname = {'linux':'libmkl_rt.so', # works for python3 on linux
            'win32':'mkl_rt.dll'}
 
 def _loadMKL():
-    
+    MKLlib = None
     try:
         # Look for MKL in path
         MKLlib = CDLL(libname[platform])
     except:
         try:
-            # Look for anaconda mkl
-            if 'Anaconda' in sys.version:
+            if platform == 'win32' and MKLlib is None:
+                try:
+                    MKLlib = CDLL('mkl_rt.1.dll')
+                except:
+                    MKLlib = CDLL('mkl_rt.2.dll')
+                
+            # Look for anaconda mkl if the MKLlib didn't load at this point
+            if 'Anaconda' in sys.version and MKLlib is None:
                 if platform in ['linux', 'linux2','darwin']:
                     libpath = ['/']+sys.executable.split('/')[:-2] + \
                               ['lib',libname[platform]]

--- a/pyMKL/loadMKL.py
+++ b/pyMKL/loadMKL.py
@@ -33,4 +33,6 @@ def _loadMKL():
         except Exception as e: 
             raise e
 
+    if MKLlib is None:
+        raise FileNotFoundError(f"Couldn't find the MKL dll.")
     return MKLlib


### PR DESCRIPTION
Fixes https://github.com/dwfmarchant/pyMKL/issues/17 where the MKL dll is not found.

It will first try to use the "mkl_rt.dll" name and then if it fails and it's on windows it will try mkl_rt.1.dll and if that isn't found, then it will try mkl_rt.2.dll.

Finally if no MKL dll is found an accurate error message will be displayed.