### PR TITLE
Specify latest mkl version in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,16 @@ pyMKL
     :alt: Travis CI build status
 
 Python wrapper of Intel MKL routines
+
+Important
+=========
+
+pyMKL is not under active current development. Use
+`pymatsolver <https://github.com/simpeg/pymatsolver>`_ if you need a Python
+wrapper for MKL solvers.
+
+Dependencies
+============
+
+The latest version of pyMKL (v0.0.3) works only with versions of
+``mkl<=2019.5``.


### PR DESCRIPTION
Add section informing users that pyMKL is not under active development.